### PR TITLE
add a name to the default package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -150,8 +150,9 @@
              cp -f ${remappings} remappings.txt
           '';
         };
-        packages = {
-          default = pkgs.stdenv.mkDerivation {
+        packages = rec {
+          default = mass-contracts;
+          mass-contracts = pkgs.stdenv.mkDerivation {
             buildInputs =
               [
                 deploy_market_store


### PR DESCRIPTION
only having `packages.default` is cumbersome in a few places, like the deployments.