### PR TITLE
add source build output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,17 @@
         };
         packages = rec {
           default = mass-contracts;
+
+          source-with-deps = pkgs.stdenv.mkDerivation {
+            name = "source-with-deps";
+            src = ./.;
+            buildPhase = ''
+              cp -r $src $out
+              chmod -R +w $out
+              cp ${remappings} $out/remappings.txt
+            '';
+          };
+
           mass-contracts = pkgs.stdenv.mkDerivation {
             inherit buildInputs;
             name = "mass-contracts";

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,0 @@
-forge-std/=/nix/store/h205l4k3bblp6s6bw99z6l6ijz3ssfcf-source/src
-openzeppelin/=/nix/store/a6i38pyzxil3h5rj9jy3kb103xq7i3ji-source
-ds-test/=/nix/store/kzbay453qngnh77mckqkmpca0vyrrp6f-source/src
-permit2/=/nix/store/bm81cc6z6k8m09jknp8g3iq411jpjgbr-source/
-solady=/nix/store/yldr7l4wpn2iimb80ri9672qrsnh53lz-source/


### PR DESCRIPTION
I couldn't use the `deploy-market` build output since at build time anvil wasn't available yet.

I tried to replicate the script in my use case but ran into issues with the remappings, since they were out of date.

Using this build target leads to also having our dependencies added to a store in a heavily sandboxed environment.

This PR

* remove the (stale) `remappings.txt`
* adds a build output with the source and remappings